### PR TITLE
UX Fixes

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -76,6 +76,17 @@ export default function Web() {
                 }),
               ],
             }),
+            textLine({
+              className: classes.customLine,
+              words: [
+                buttonWord({
+                  characters: 'disabled button word',
+                  disabled: true,
+                  /* eslint-disable-next-line */
+                  onClick: () => alert('You clicked a button'),
+                }),
+              ],
+            }),
             inlineTextLine({
               className: classes.customLine,
               words: [

--- a/packages/crt-terminal/src/API/sentence/sentence.ts
+++ b/packages/crt-terminal/src/API/sentence/sentence.ts
@@ -35,6 +35,7 @@ interface InlineTextWord extends BaseWord {
 
 interface ButtonWord extends BaseWord {
   type: WordTypes.BUTTON;
+  disabled?: boolean;
   onClick?: ButtonCallback;
 }
 
@@ -86,6 +87,7 @@ type ButtonProps = Omit<ButtonWord, 'type'>;
 
 const buttonWord = ({
   characters,
+  disabled,
   onClick,
   dataAttribute,
   className,
@@ -93,6 +95,7 @@ const buttonWord = ({
 }: ButtonProps): ButtonWord => ({
   type: WordTypes.BUTTON,
   characters,
+  disabled,
   onClick,
   dataAttribute,
   id,

--- a/packages/crt-terminal/src/components/Character/Character.tsx
+++ b/packages/crt-terminal/src/components/Character/Character.tsx
@@ -4,17 +4,20 @@ import classes from './character.module.scss';
 interface CharacterProps {
   selected?: boolean;
   className?: string;
+  hasFocus?: boolean;
 }
 
 const Character = function Character({
   children,
   selected = false,
   className = '',
+  hasFocus = true,
 }: PropsWithChildren<CharacterProps>) {
   const selectedStyle = selected ? classes.characterSelected : '';
+  const focusStyle = (selected === true && hasFocus === false) ? classes.characterSelectedNotFocused : ''
 
   return (
-    <span className={[classes.character, selectedStyle, className, 'crt-character'].join(' ')}>
+    <span className={[classes.character, selectedStyle, focusStyle, className, 'crt-character'].join(' ')}>
       {children}
     </span>
   );

--- a/packages/crt-terminal/src/components/Character/character.module.scss
+++ b/packages/crt-terminal/src/components/Character/character.module.scss
@@ -7,7 +7,17 @@
 }
 
 .characterSelected {
+  margin: -1px;
   color: $cursor-contrast-color;
   background-color: $cursor-color;
+  border: 1px solid transparent;
   animation: blink-character 1s steps(1, end) infinite;
+}
+
+.characterSelectedNotFocused {
+  margin: -1px;
+  color: $cursor-color;
+  background-color: transparent;
+  border: 1px solid $cursor-color;
+  animation: none;
 }

--- a/packages/crt-terminal/src/components/CommandLine/CommandLine.tsx
+++ b/packages/crt-terminal/src/components/CommandLine/CommandLine.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { CommandLine as CommandLineState } from '../../hooks/terminal/useCommandLine';
 import { TerminalControllerReturnType } from '../../hooks/useTerminalController';
 import Character from '../Character/Character';
@@ -35,6 +35,16 @@ const CommandLine = React.forwardRef<HTMLInputElement, CommandLineProps>(
       handleKeyboardDown(event);
     };
 
+    const [hasFocus, setHasFocus] = useState<boolean>(false)
+    
+    const handleOnFocus = () => {
+      setHasFocus(true)
+    }
+
+    const handleOnBlur = () => {
+      setHasFocus(false)
+    }
+
     const lastSelected = cursorPosition === renderValue.length;
 
     return (
@@ -48,13 +58,15 @@ const CommandLine = React.forwardRef<HTMLInputElement, CommandLineProps>(
             value={inputValue}
             onInput={handleInput}
             onKeyDown={handleKeyDown}
+            onFocus={handleOnFocus}
+            onBlur={handleOnBlur}
             autoComplete={autoComplete ? "on" : "off"}
             type="text"
           />
           <div className={[classes.inputString, 'crt-command-line__input-string'].join(' ')}>
-            <InputString renderValue={renderValue} cursorPosition={cursorPosition} />
+            <InputString renderValue={renderValue} cursorPosition={cursorPosition} hasFocus={hasFocus} />
             {lastSelected && (
-              <Character className="crt-cursor-symbol" selected>
+              <Character className="crt-cursor-symbol" selected hasFocus={hasFocus}>
                 {cursorSymbol}
               </Character>
             )}

--- a/packages/crt-terminal/src/components/CommandLine/CommandLine.tsx
+++ b/packages/crt-terminal/src/components/CommandLine/CommandLine.tsx
@@ -12,6 +12,7 @@ interface CommandLineProps {
   state: CommandLineState;
   handleKeyboardDown: TerminalControllerReturnType['handlers']['handleKeyboardDown'];
   handleInputChange: TerminalControllerReturnType['handlers']['handleInputChange'];
+  autoComplete: boolean;
 }
 
 const CommandLine = React.forwardRef<HTMLInputElement, CommandLineProps>(
@@ -22,6 +23,7 @@ const CommandLine = React.forwardRef<HTMLInputElement, CommandLineProps>(
       handleInputChange,
       prompt,
       cursorSymbol,
+      autoComplete,
     },
     inputElement,
   ) => {
@@ -46,6 +48,7 @@ const CommandLine = React.forwardRef<HTMLInputElement, CommandLineProps>(
             value={inputValue}
             onInput={handleInput}
             onKeyDown={handleKeyDown}
+            autoComplete={autoComplete ? "on" : "off"}
             type="text"
           />
           <div className={[classes.inputString, 'crt-command-line__input-string'].join(' ')}>

--- a/packages/crt-terminal/src/components/CommandLine/components/Input.tsx
+++ b/packages/crt-terminal/src/components/CommandLine/components/Input.tsx
@@ -33,10 +33,15 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       input.value = value as string;
       input.setAttribute('value', value as string);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   const onKeyDownInner = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // ignore tabs
+    if (e.key === 'Tab') {
+      e.preventDefault()
+      return
+    }
     // return when inputing chinese pinyin
     if (inputing.current) return;
     onKeyDown?.(e);

--- a/packages/crt-terminal/src/components/CommandLine/components/Input.tsx
+++ b/packages/crt-terminal/src/components/CommandLine/components/Input.tsx
@@ -23,6 +23,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     onBlur,
     value,
     defaultValue,
+    autoComplete,
     ...attrs
   } = props;
   const mergeValue = ('value' in props) ? value : defaultValue;
@@ -115,6 +116,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       onInput={onInputInner}
       onKeyDown={onKeyDownInner}
       onChange={onChangeInner}
+      autoComplete={autoComplete}
     />
   );
 });

--- a/packages/crt-terminal/src/components/CommandLine/components/Input.tsx
+++ b/packages/crt-terminal/src/components/CommandLine/components/Input.tsx
@@ -38,11 +38,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   }, [value]);
 
   const onKeyDownInner = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    // ignore tabs
-    if (e.key === 'Tab') {
-      e.preventDefault()
-      return
-    }
     // return when inputing chinese pinyin
     if (inputing.current) return;
     onKeyDown?.(e);

--- a/packages/crt-terminal/src/components/CommandLine/components/InputString/InputString.tsx
+++ b/packages/crt-terminal/src/components/CommandLine/components/InputString/InputString.tsx
@@ -5,12 +5,13 @@ import Character from '../../../Character/Character';
 interface InputStringProps {
   cursorPosition: number;
   renderValue: RenderList;
+  hasFocus?: boolean;
 }
 
-const InputString = memo(({ cursorPosition, renderValue }: InputStringProps) => (
+const InputString = memo(({ cursorPosition, renderValue, hasFocus }: InputStringProps) => (
   <>
     {renderValue.map((character, key) => (
-      <Character selected={cursorPosition === key} key={key}>
+      <Character selected={cursorPosition === key} key={key} hasFocus={hasFocus}>
         {character}
       </Character>
     ))}

--- a/packages/crt-terminal/src/components/PrinterWord/PrinterWord.tsx
+++ b/packages/crt-terminal/src/components/PrinterWord/PrinterWord.tsx
@@ -46,6 +46,7 @@ const PrinterWord = function PrinterWord({ word, children }: PropsWithChildren<P
             className={[classes.buttonWord, 'crt-button-word', className].join(' ')}
             data-crt-terminal={dataAttribute}
             onClick={word.onClick}
+            disabled={word.disabled}
           >
             <Character>{children}</Character>
           </button>

--- a/packages/crt-terminal/src/components/PrinterWord/printer-word.module.scss
+++ b/packages/crt-terminal/src/components/PrinterWord/printer-word.module.scss
@@ -22,6 +22,13 @@
     color: $secondary-color;
     background-color: $main-color;
   }
+
+  &:disabled {
+    color: $main-color;
+    opacity: 36%;
+    background-color: transparent;
+    cursor: not-allowed;
+  }
 }
 
 .anchorWord {

--- a/packages/crt-terminal/src/components/PrinterWord/printer-word.module.scss
+++ b/packages/crt-terminal/src/components/PrinterWord/printer-word.module.scss
@@ -24,8 +24,8 @@
   }
 
   &:disabled {
+    opacity: 0.36;
     color: $main-color;
-    opacity: 36%;
     background-color: transparent;
     cursor: not-allowed;
   }

--- a/packages/crt-terminal/src/components/Terminal/Terminal.tsx
+++ b/packages/crt-terminal/src/components/Terminal/Terminal.tsx
@@ -49,6 +49,7 @@ interface TerminalProps {
   };
   focusOnMount?: boolean;
   allowEmptyCommand?: boolean;
+  autoComplete?: boolean;
 }
 
 const Terminal = function Terminal({
@@ -65,6 +66,7 @@ const Terminal = function Terminal({
   effects: { scanner = true, pixels = true, screenEffects = true, textEffects = true } = {},
   focusOnMount = true,
   allowEmptyCommand = false,
+  autoComplete = false,
 }: TerminalProps) {
   const terminalApp = useTerminalApp();
   const {
@@ -133,6 +135,7 @@ const Terminal = function Terminal({
                 state={commandLine.state}
                 handleKeyboardDown={handleKeyboardDown}
                 handleInputChange={handleInputChange}
+                autoComplete={autoComplete}
               />
             </div>
           </TextEffects>


### PR DESCRIPTION
- Ignore tabs is a partial solution for loss of focus issues which happen when users press "Tab" and focus is lost from the input field
- Add param to optionally disable buttons
- Add param to disable autocorrect (new default is disabled)
- Add unfocused state for cursor style is another partial solution for loss of focus issues which happen when users interact with elements outside the terminal and are confused when focus is lost.